### PR TITLE
[FEAT] #1 고급 페이지네이션 컴포넌트  구현

### DIFF
--- a/src/components/ui/AdvancedPagination.js
+++ b/src/components/ui/AdvancedPagination.js
@@ -1,0 +1,209 @@
+'use client';
+import React, { useState } from 'react';
+import styles from "@/styles/common/Pagination.module.css";
+
+const AdvancedPagination = ({ 
+  currentPage, 
+  totalPages, 
+  totalItems,
+  itemsPerPage,
+  onPageChange,
+  onPageSizeChange = () => {}, // Add default empty function
+  showFirstLast = false,
+  maxVisiblePages = 10,
+  showPageSizeSelector = true,
+  showItemInfo = true,
+  pageSizeOptions = [5, 10, 20, 50, 100],
+  className = ""
+}) => {
+  const [inputPage, setInputPage] = useState('');
+
+  if (totalPages <= 1 && !showPageSizeSelector) return null;
+
+  // 현재 페이지의 아이템 범위 계산
+  const startItem = (currentPage - 1) * itemsPerPage + 1;
+  const endItem = Math.min(currentPage * itemsPerPage, totalItems);
+
+  // 표시할 페이지 번호 범위 계산
+  const getPageNumbers = () => {
+    const pages = [];
+    const halfVisible = Math.floor(maxVisiblePages / 2);
+    
+    let startPage = Math.max(1, currentPage - halfVisible);
+    let endPage = Math.min(totalPages, startPage + maxVisiblePages - 1);
+    
+    if (endPage - startPage + 1 < maxVisiblePages) {
+      startPage = Math.max(1, endPage - maxVisiblePages + 1);
+    }
+    
+    for (let i = startPage; i <= endPage; i++) {
+      pages.push(i);
+    }
+    
+    return pages;
+  };
+
+  // 페이지 직접 입력 핸들러
+  const handleGoToPage = (e) => {
+    e.preventDefault();
+    const page = parseInt(inputPage);
+    if (page >= 1 && page <= totalPages) {
+      onPageChange(page);
+      setInputPage('');
+    }
+  };
+
+  // 페이지 사이즈 변경 핸들러
+  const handlePageSizeChange = (e) => {
+    const newSize = parseInt(e.target.value);
+    
+    // Check if onPageSizeChange is provided and is a function
+    if (typeof onPageSizeChange === 'function') {
+      onPageSizeChange(newSize);
+      // 새로운 페이지 사이즈에 맞게 현재 페이지 조정
+      const newTotalPages = Math.ceil(totalItems / newSize);
+      if (currentPage > newTotalPages) {
+        onPageChange(newTotalPages);
+      }
+    }
+  };
+
+  const pageNumbers = getPageNumbers();
+
+  return (
+    <div className={`${styles.paginationContainer} ${className}`}>
+      {/* 페이지 정보 및 사이즈 선택 */}
+      <div className={styles.paginationInfo}>
+        {showItemInfo && (
+          <span className={styles.itemInfo}>
+            {startItem}-{endItem} / {totalItems}개
+          </span>
+        )}
+        
+        {showPageSizeSelector && (
+          <div className={styles.pageSizeSelector}>
+            <label>
+              페이지당 
+              <select 
+                value={itemsPerPage} 
+                onChange={handlePageSizeChange}
+                className={styles.pageSizeSelect}
+              >
+                {pageSizeOptions.map(size => (
+                  <option key={size} value={size}>{size}</option>
+                ))}
+              </select>
+              개씩
+            </label>
+          </div>
+        )}
+      </div>
+
+      {/* 페이지네이션 버튼들 */}
+      <div className={styles.pagination}>
+        {/* 첫 페이지 버튼 */}
+        {showFirstLast && currentPage > 1 && (
+          <button
+            className={styles.paginationButton}
+            onClick={() => onPageChange(1)}
+            title="첫 페이지"
+          >
+            ≪
+          </button>
+        )}
+
+        {/* 이전 페이지 버튼 */}
+        <button
+          className={styles.paginationButton}
+          onClick={() => onPageChange(Math.max(currentPage - 1, 1))}
+          disabled={currentPage === 1}
+        >
+          이전
+        </button>
+
+        {/* 시작 생략 표시 */}
+        {pageNumbers[0] > 1 && (
+          <>
+            <button
+              className={styles.paginationButton}
+              onClick={() => onPageChange(1)}
+            >
+              1
+            </button>
+            {pageNumbers[0] > 2 && (
+              <span className={styles.ellipsis}>...</span>
+            )}
+          </>
+        )}
+
+        {/* 페이지 번호 버튼들 */}
+        {pageNumbers.map(page => (
+          <button
+            key={page}
+            className={`${styles.paginationButton} ${
+              page === currentPage ? styles.active : ''
+            }`}
+            onClick={() => onPageChange(page)}
+          >
+            {page}
+          </button>
+        ))}
+
+        {/* 끝 생략 표시 */}
+        {pageNumbers[pageNumbers.length - 1] < totalPages && (
+          <>
+            {pageNumbers[pageNumbers.length - 1] < totalPages - 1 && (
+              <span className={styles.ellipsis}>...</span>
+            )}
+            <button
+              className={styles.paginationButton}
+              onClick={() => onPageChange(totalPages)}
+            >
+              {totalPages}
+            </button>
+          </>
+        )}
+
+        {/* 다음 페이지 버튼 */}
+        <button
+          className={styles.paginationButton}
+          onClick={() => onPageChange(Math.min(currentPage + 1, totalPages))}
+          disabled={currentPage === totalPages}
+        >
+          다음
+        </button>
+
+        {/* 마지막 페이지 버튼 */}
+        {showFirstLast && currentPage < totalPages && (
+          <button
+            className={styles.paginationButton}
+            onClick={() => onPageChange(totalPages)}
+            title="마지막 페이지"
+          >
+            ≫
+          </button>
+        )}
+      </div>
+
+      {/* 페이지 직접 입력 */}
+      <div className={styles.pageJump}>
+        <form onSubmit={handleGoToPage} className={styles.pageJumpForm}>
+          <input
+            type="number"
+            min="1"
+            max={totalPages}
+            value={inputPage}
+            onChange={(e) => setInputPage(e.target.value)}
+            placeholder="페이지"
+            className={styles.pageJumpInput}
+          />
+          <button type="submit" className={styles.pageJumpButton}>
+            이동
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default AdvancedPagination;

--- a/src/styles/common/Pagination.module.css
+++ b/src/styles/common/Pagination.module.css
@@ -1,0 +1,296 @@
+/* src/styles/common/Pagination.module.css */
+
+/* =================================
+   페이지네이션 컨테이너
+   ================================= */
+.paginationContainer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: var(--spacing-xl);
+  padding: var(--spacing-lg) 0;
+  border-top: 1px solid var(--color-secondary2);
+  flex-wrap: wrap;
+  gap: var(--spacing-lg);
+}
+
+/* 세 섹션을 동일한 너비로 설정 */
+.paginationInfo {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-lg);
+  justify-content: flex-start; /* 왼쪽 정렬 */
+  min-width: 0; /* flex-shrink 허용 */
+  color: var(--text-secondary);
+}
+
+.itemInfo {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  white-space: nowrap;
+}
+
+.pageSizeSelector {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.pageSizeSelect {
+  padding: var(--spacing-xs) var(--spacing-sm);
+  border: 1px solid var(--color-secondary2);
+  border-radius: var(--radius-sm);
+  background: var(--bg-primary);
+  font-size: var(--text-sm);
+  margin: 0 var(--spacing-xs);
+  color: var(--text-secondary);
+  transition: var(--transition-fast);
+  cursor: pointer;
+}
+
+.pageSizeSelect:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 2px rgba(var(--color-primary-rgb), 0.1);
+}
+
+/* =================================
+   페이지네이션 버튼
+   ================================= */
+.pagination {
+  flex: 1;
+  display: flex;
+  justify-content: center; /* 가운데 정렬 */
+  align-items: center;
+  gap: var(--spacing-sm);
+  min-width: 0; /* flex-shrink 허용 */
+}
+
+.paginationButton {
+  padding: var(--spacing-md) var(--spacing-lg);
+  border: 2px solid var(--color-secondary2);
+  background: var(--bg-primary);
+  color: var(--color-primary);
+  border-radius: var(--radius-xl);
+  cursor: pointer;
+  transition: var(--transition-fast);
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  min-width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.paginationButton:hover:not(:disabled) {
+  background: var(--color-background);
+  border-color: var(--color-light-gray);
+  transform: translateY(-1px);
+}
+
+.paginationButton:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  transform: none;
+  background: var(--color-background);
+}
+
+.paginationButton.active {
+  background: var(--color-primary);
+  color: var(--text-light);
+  border-color: var(--color-primary);
+}
+
+.paginationButton.active:hover {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  transform: translateY(-1px);
+}
+
+.ellipsis {
+  padding: var(--spacing-sm) var(--spacing-xs);
+  color: var(--color-text-secondary);
+  font-size: var(--text-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  height: 44px;
+}
+
+/* =================================
+   페이지 점프 (직접 이동)
+   ================================= */
+.pageJump {
+  flex: 1;
+  display: flex;
+  justify-content: flex-end; /* 오른쪽 정렬 */
+  align-items: center;
+  gap: var(--spacing-sm);
+  min-width: 0; /* flex-shrink 허용 */
+}
+
+.pageJumpForm {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+.pageJumpInput {
+  width: 60px;
+  padding: var(--spacing-sm) var(--spacing-md);
+  border: 1px solid var(--color-secondary2);
+  border-radius: var(--radius-sm);
+  text-align: center;
+  font-size: var(--text-sm);
+  background: var(--bg-primary);
+  color: var(--text-secondary);
+  transition: var(--transition-fast);
+}
+
+.pageJumpInput:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 2px rgba(var(--color-primary-rgb), 0.1);
+}
+
+.pageJumpButton {
+  padding: var(--spacing-sm) var(--spacing-lg);
+  background: var(--color-gray-200);
+  color: var(--text-secondary);
+  border: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  transition: var(--transition-fast);
+}
+
+.pageJumpButton:hover {
+  transform: translateY(-2px);
+}
+
+/* =================================
+   반응형 디자인
+   ================================= */
+@media (max-width: 768px) {
+  .paginationContainer {
+    flex-direction: column;
+    align-items: stretch;
+    gap: var(--spacing-lg);
+  }
+
+  .paginationInfo,
+  .pagination,
+  .pageJump {
+    flex: none;
+    width: 100%;
+    justify-content: center;
+  }
+
+  .paginationInfo {
+    flex-direction: column;
+    gap: var(--spacing-md);
+  }
+
+  .pagination {
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: var(--spacing-xs);
+  }
+
+  .pageJump {
+    justify-content: center;
+  }
+
+  .paginationButton {
+    padding: var(--spacing-sm) var(--spacing-md);
+    min-width: 36px;
+    height: 36px;
+    font-size: var(--text-xs);
+  }
+
+  .ellipsis {
+    min-width: 36px;
+    height: 36px;
+  }
+}
+
+/* 매우 작은 화면에서 버튼 크기 조정 */
+@media (max-width: 480px) {
+  .paginationButton {
+    padding: var(--spacing-xs) var(--spacing-sm);
+    min-width: 32px;
+    height: 32px;
+    font-size: var(--text-xs);
+  }
+
+  .ellipsis {
+    min-width: 32px;
+    height: 32px;
+  }
+
+  .itemInfo {
+    font-size: var(--text-xs);
+  }
+
+  .pageSizeSelector {
+    font-size: var(--text-xs);
+  }
+
+  .pageJumpInput {
+    width: 50px;
+    padding: var(--spacing-xs) var(--spacing-sm);
+    font-size: var(--text-xs);
+  }
+
+  .pageJumpButton {
+    padding: var(--spacing-xs) var(--spacing-sm);
+    font-size: var(--text-xs);
+  }
+}
+
+/* =================================
+   변형 스타일
+   ================================= */
+.pagination.simple {
+  justify-content: center;
+  margin-top: var(--spacing-xl);
+}
+
+.pagination.simple .paginationButton {
+  margin: 0 var(--spacing-xs);
+}
+
+.pagination.compact {
+  gap: var(--spacing-xs);
+}
+
+.pagination.compact .paginationButton {
+  padding: var(--spacing-sm) var(--spacing-md);
+  min-width: 36px;
+  height: 36px;
+  font-size: var(--text-xs);
+}
+
+/* =================================
+   테마별 색상 (필요시 사용)
+   ================================= */
+.pagination.minimal .paginationButton {
+  border: 1px solid var(--color-secondary2);
+  background: transparent;
+}
+
+.pagination.minimal .paginationButton:hover:not(:disabled) {
+  background: var(--color-background);
+}
+
+.pagination.minimal .paginationButton.active {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+}


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가 <br>

## 👍변경점
- ** 100건 이상의 데이터를 다룰시, 백엔드에서 페이징 기능구현을 권장하나, 일단 간단히 프론트에서 페이징 기능 구현
- 현재 페이지, 전체 페이지 수, 전체 항목 수 기반의 페이지네이션 기능 제공
- 페이지 이동, 직접 입력, 페이지 사이즈 변경 기능 포함
- 처음/마지막 페이지 버튼, 페이지 범위 설정 등 커스터마이징 옵션 제공
- 항목 수 표시, 페이지 사이즈 셀렉터 등 선택적 렌더링 지원

## 스크린샷 (선택)
<img width="1628" height="403" alt="스크린샷 2025-07-16 오전 12 05 05" src="https://github.com/user-attachments/assets/5e11ec2c-7627-4ba4-bd90-340938da3eff" />

