### PR TITLE
[FIX] 사이드바 메뉴에 샵 등록 및 관리 추가, 유저 정보가 불러지지 않는 오류 수정

### DIFF
--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -23,6 +23,7 @@ export default function Layout({ children }) {
   // 사용자 권한 상태 관리
   const [userRole, setUserRole] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [userInfo, setUserInfo] = useState(null);
 
   // 사용자 정보 로드
   useEffect(() => {
@@ -49,6 +50,7 @@ export default function Layout({ children }) {
           const userData = responseData.data;
 
           console.log('Layout: 사용자 정보 로드 성공:', userData);
+          setUserInfo(userData);
           setUserRole(userData.admin ? 2 : 1);
         } else if (response.status === 401 || response.status === 403) {
           console.error('Layout: 사용자 정보를 가져올 수 없습니다. 토큰 만료 또는 권한 없음.', response.status);
@@ -155,6 +157,7 @@ export default function Layout({ children }) {
         userRole={userRole} // Layout에서 관리하는 권한 전달
         viewMode={viewMode}
         onViewModeChange={handleViewModeChange}
+        userInfo={userInfo}
       />
 
       {/* 메인 콘텐츠 */}

--- a/src/components/layout/SideMenuBar.jsx
+++ b/src/components/layout/SideMenuBar.jsx
@@ -76,7 +76,7 @@ const UserProfile = ({ userRole, isAdmin, getProfilePath, userInfo }) => {
       // 권한 1: 일반고객 - 고객이름과 아이디
       return {
         displayName: userInfo?.userName || "홍길동",
-        displayId: userInfo?.customerId || "customer123",
+        displayId: userInfo?.userId || "customer123",
         circleText: userInfo?.userName?.charAt(0) || "홍",
         isCustomer: true
       };

--- a/src/components/layout/SideMenuBar.jsx
+++ b/src/components/layout/SideMenuBar.jsx
@@ -51,6 +51,12 @@ const MENU_CONFIG = {
         { path: "/myshop/message/auto-setting", text: "자동 발송 설정" },
         { path: "/myshop/message/list", text: "메시지 조회" }
       ]
+    },
+    {
+      key: "admin-shop",
+      title: "샵 등록 및 관리",
+      type: "direct", // 바로 이동하는 메뉴
+      path: "/myshop"
     }
   ],
   customer: [

--- a/src/components/layout/SideMenuBar.jsx
+++ b/src/components/layout/SideMenuBar.jsx
@@ -68,21 +68,24 @@ const MENU_CONFIG = {
 // 사용자 프로필 컴포넌트 분리
 const UserProfile = ({ userRole, isAdmin, getProfilePath, userInfo }) => {
   // 권한별 프로필 정보 설정
+
+  console.log( '유저인포 확인',userInfo)
+
   const getProfileInfo = () => {
     if (userRole === 1) {
       // 권한 1: 일반고객 - 고객이름과 아이디
       return {
-        displayName: userInfo?.customerName || "홍길동",
+        displayName: userInfo?.userName || "홍길동",
         displayId: userInfo?.customerId || "customer123",
-        circleText: userInfo?.customerName?.charAt(0) || "홍",
+        circleText: userInfo?.userName?.charAt(0) || "홍",
         isCustomer: true
       };
     } else if (userRole === 2) {
       // 권한 2: 샵관리자 - 회원아이디와 샵이름
       return {
-        displayName: userInfo?.shopName || "펌앤코드",
+        displayName: userInfo?.userName || "펌앤코드",
         displayId: userInfo?.userId || "boa",
-        circleText: userInfo?.shopName?.charAt(0) || "펌",
+        circleText: userInfo?.userName?.charAt(0) || "펌",
         isCustomer: false
       };
     }


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가 <br>
- [ ] 기능 삭제 <br>
- [ ] 버그 수정 <br>
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
 
## 🛠리팩토링

- 관리자가 로그인하면 /myshop으로 전환하는 메뉴가 안 보여서 사이드바에 추가했습니다.
- 로그인시 page에서 받아오는 userInfo가 sidebar로 넘어가지 않는 문제를 해결했습니다.
- 본래 관리자는 샵 이름이 들어가야 하지만, 받아오는 정보의 userInfo에 샵 정보가 없어 임시로 있는 데이터로 처리했습니다.

## 스크린샷 (선택)

<img width="251" height="620" alt="image" src="https://github.com/user-attachments/assets/1a5b881d-b0d3-4f73-a0fe-9f8dc63bd87b" />
<img width="325" height="109" alt="image" src="https://github.com/user-attachments/assets/9663b35e-7796-4bf8-a5a0-6314a9204429" />

 
