### PR TITLE
[FIX] #73 인사이트 매출 부분 시술별 최고가를 최고 매출월로 표시 변경

### DIFF
--- a/src/app/myshop/sales/statistics/page.js
+++ b/src/app/myshop/sales/statistics/page.js
@@ -121,7 +121,7 @@ const SalesStatistics = () => {
       {monthlyTrend.data.length > 0 && (
         <DetailedAnalysisTable
           data={monthlyTrend}
-          title="금년 월별 매출 분석"
+          title="월별 매출 분석 (월별매출추이 필터 적용)"
         />
       )}
     </div>

--- a/src/components/sales/statistics/InsightsSection.jsx
+++ b/src/components/sales/statistics/InsightsSection.jsx
@@ -46,16 +46,13 @@ const InsightsSection = ({ monthlyTrend, categoryStats, paymentMethodStats, tran
         <div className={styles.insightCard}>
           <h4 className={styles.insightTitle}>매출 트렌드</h4>
           <p className={styles.insightText}>
-            {monthlyTrend.data.length > 1 ? (
-              `최근 ${monthlyTrend.data.length}개월 중 최고 매출: ${Math.max(
-                ...monthlyTrend.data.map(d => {
-                  const num = Number(d.amount);
-                  return !isNaN(num) ? num : 0;
-                })
-              ).toLocaleString()}원`
-            ) : (
-              '충분한 데이터가 필요합니다.'
-            )}
+            {monthlyTrend.data.length > 1 ? (() => {
+              // 가장 높은 매출 찾기
+              const maxItem = monthlyTrend.data.reduce((max, cur) =>
+                Number(cur.totalAmount) > Number(max.totalAmount) ? cur : max
+              );
+              return `가장 높은 매출: ${Number(maxItem.totalAmount).toLocaleString()}원 (${maxItem.label})`;
+            })() : '충분한 데이터가 필요합니다.'}
           </p>
           {/* 
               향후 확장 가능한 분석:


### PR DESCRIPTION
- 매출 인사이트에서 시술별 최고가 표시를 최고 매출월로 변경
- 관련 prop 및 데이터 처리 로직 수정

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 버그 수정 <br>

## 👍변경점
### 매출 인사이트 표시 항목 개선
- 기존 매출 인사이트에서 "시술별 최고가"로 표시되던 부분을 "최고 매출월"로 변경하여 사용자에게 더 유용한 정보를 제공하도록 개선
- 데이터 포맷팅 로직 조정 (가격 → 월/연도 형식)

## 스크린샷 (선택)
<img width="1110" height="138" alt="스크린샷 2025-07-23 오후 7 19 22" src="https://github.com/user-attachments/assets/b7ddb1a6-dc68-4516-b233-42d6d42fb415" />

