### PR TITLE
[FEATURE] #116 유저 예약 챗봇 프론트 연결

### DIFF
--- a/src/app/shops/components/KakaoMap.js
+++ b/src/app/shops/components/KakaoMap.js
@@ -61,7 +61,9 @@ export default function KakaoMap({ shops, userLocation, onMarkerClick, selectedS
 
   // Script 로드 완료 시 지도 초기화
   const handleScriptLoad = () => {
-    window.kakao.maps.load(initializeMap);
+    if (window.kakao && window.kakao.maps) {
+      window.kakao.maps.load(initializeMap);
+    }
   };
 
   // shops 데이터가 변경될 때마다 마커를 다시 그림
@@ -70,6 +72,14 @@ export default function KakaoMap({ shops, userLocation, onMarkerClick, selectedS
       drawMarkers();
     }
   }, [shops]); // shops 배열이 바뀔 때만 마커 새로고침
+
+  useEffect(() => {
+    // 컴포넌트가 마운트될 때 카카오 지도 스크립트가 이미 로드되어 있는지 확인
+    if (window.kakao && window.kakao.maps) {
+      // 이미 로드되었다면, onLoad를 기다리지 않고 즉시 지도 초기화
+      handleScriptLoad();
+    }
+  }, [])
 
   return (
       <>

--- a/src/app/shops/page.js
+++ b/src/app/shops/page.js
@@ -9,7 +9,6 @@ import ShopDetailPanel from "@/app/shops/components/ShopDetailPanel";
 import BookingFormPanel from "@/app/shops/components/BookingFormPanel";
 import 'src/styles/user/shops/ShopFinder.css';
 import KakaoMap from "@/app/shops/components/KakaoMap";
-import { da } from 'date-fns/locale';
 
 export default function Shops() {
     // 현재 화면 상태

--- a/src/app/shops/page.js
+++ b/src/app/shops/page.js
@@ -1,6 +1,7 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
+import { ShopsEvent } from '@/lib/util/shopsEvent';
 import useUserLocation from "@/app/shops/util/useUserLocation";
 import ShopAlertModal from "@/app/shops/components/ShopAlertModal";
 import ShopListPanel from "@/app/shops/components/ShopListPanel";
@@ -8,6 +9,7 @@ import ShopDetailPanel from "@/app/shops/components/ShopDetailPanel";
 import BookingFormPanel from "@/app/shops/components/BookingFormPanel";
 import 'src/styles/user/shops/ShopFinder.css';
 import KakaoMap from "@/app/shops/components/KakaoMap";
+import { da } from 'date-fns/locale';
 
 export default function Shops() {
     // 현재 화면 상태
@@ -24,10 +26,11 @@ export default function Shops() {
 
     const { location: userLocation } = useUserLocation();
 
-    const handleShopSelect = (shopCode) => {
+    // useEffect 사용을 위해 useCallback으로 변경함
+    const handleShopSelect = useCallback((shopCode) => {
         setSelectedShop({code: shopCode});
         setView('detail');
-    };
+    }, []);
 
     // 상세 조회에서 불러왔던 정보 사용
     const handleShowBooking = (shopInfo, groupedMenus) => {
@@ -62,6 +65,22 @@ export default function Shops() {
         setSelectedShop({code: shop.shopCode});
         setView('detail');
     }
+
+    useEffect(() => {
+        const handleShopSelectionEvent = (data) => {
+            console.log('selectShop 이벤트 발생: ', data)
+            if (data?.shopCode) {
+                handleShopSelect(data.shopCode)
+            }
+        };
+
+        ShopsEvent.on('selectShop', handleShopSelectionEvent);
+
+        return () => {
+            ShopsEvent.remove('selectShop', handleShopSelectionEvent)
+        }
+
+    }, [handleShopSelect])
 
     return (
         <div className={'map-page-container'}>

--- a/src/app/shops/page.js
+++ b/src/app/shops/page.js
@@ -81,6 +81,17 @@ export default function Shops() {
 
     }, [handleShopSelect])
 
+    useEffect(() => {
+        
+        const pendingShopCode = sessionStorage.getItem('pendingShopSelection');
+
+        if (pendingShopCode) {
+            handleShopSelect(pendingShopCode);
+            sessionStorage.removeItem('pendingShopSelection')
+        }
+
+    }, [handleShopSelect])
+
     return (
         <div className={'map-page-container'}>
             {alert &&

--- a/src/components/chat/ChatWindow.js
+++ b/src/components/chat/ChatWindow.js
@@ -3,6 +3,7 @@
 import { useState, useRef, useEffect } from 'react';
 import { ChatbotAPI } from '@/lib/api/chatbot';
 import { useApi } from '@/hooks/useApi';
+import { ShopsEvent } from '@/lib/util/shopsEvent';
 import { useRouter } from 'next/navigation';
 import MessageBubble from './MessageBubble';
 import QuickActions from './QuickActions';
@@ -282,8 +283,10 @@ const handleApiAction = (action, message) => {
 
         if (message.data.recommendation.shopCode && message.data.recommendation.menus) {
             // 샵 추천 내용이 있을 때만 router push
-
-            router.push(`/shops`);
+            ShopsEvent.dispatch('selectShop', {shopCode})
+            if(onClose) onClose();
+        } else {
+            console.error('SHOW_SHOP_DETAILS action - shop 정보 비어있음: ', action)
         }
     } 
     }; 

--- a/src/components/chat/ChatWindow.js
+++ b/src/components/chat/ChatWindow.js
@@ -266,20 +266,26 @@ export default function ChatWindow({
     };
 
 
-const handleApiAction = (action) => {
+const handleApiAction = (action, message) => {
 
-    console.log('handleApiAction', action)
+    console.log('handleApiAction', action, message)
 
     if (action.type === 'NAVIGATE') {
         router.push(action.payload.url);
-        if (onClose) {
-            onClose(); // 예약 조회 페이지로 이동하고, 채팅이 닫힘
-        }
-    } else if (action.type === 'SHOW_SHOP_DETAILS') {
-        console.log("Show shop details:", action.payload.shopCode);
-            // TODO. 샵 상세 정보 모달을 띄우는 등의 로직
-    }
 
+        if (onClose) onClose(); // 예약 조회 페이지로 이동하고, 채팅이 닫힘
+
+    } else if (action.type === 'SHOW_SHOP_DETAILS') {
+        const shopCode = action.payload.shopCode
+
+        console.log("shopCode 확인 :", shopCode);
+
+        if (message.data.recommendation.shopCode && message.data.recommendation.menus) {
+            // 샵 추천 내용이 있을 때만 router push
+
+            router.push(`/shops`);
+        }
+    } 
     }; 
 
     return (

--- a/src/components/chat/ChatWindow.js
+++ b/src/components/chat/ChatWindow.js
@@ -13,7 +13,8 @@ export default function ChatWindow({
     onBack, 
     onNewMessage, 
     userRole, 
-    userInfo 
+    userInfo,
+    onClose 
 }) {
     // const shopId = userInfo?.shopCode || userInfo?.userCode || 1;
     const shopId = userInfo?.shopCode || 1;
@@ -81,9 +82,9 @@ export default function ChatWindow({
                 case 'booking-helper':
                     return [
                         { label: '예약 조회', message: '내 예약 확인해줘' },
-                        { label: '예약 변경', message: '예약 시간 변경하고 싶어' },
                         { label: '예약 취소', message: '예약 취소하고 싶어' },
-                        { label: '새 예약', message: '새로 예약하고 싶어' }
+                        { label: '예약 변경', message: '예약 시간 변경하고 싶어' },
+                        { label: '샵 추천', message: '샵 추천해줘' }
                     ];
                 case 'inquiry-helper':
                     return [
@@ -265,14 +266,21 @@ export default function ChatWindow({
     };
 
 
-// const handleApiAction = (action) => {
-//         if (action.type === 'NAVIGATE') {
-//             router.push(action.payload.url);
-//         } else if (action.type === 'SHOW_SHOP_DETAILS') {
-//             console.log("Show shop details:", action.payload.shopCode);
-                // TODO. 샵 상세 정보 모달을 띄우는 등의 로직
-//         }
-//     };
+const handleApiAction = (action) => {
+
+    console.log('handleApiAction', action)
+
+    if (action.type === 'NAVIGATE') {
+        router.push(action.payload.url);
+        if (onClose) {
+            onClose(); // 예약 조회 페이지로 이동하고, 채팅이 닫힘
+        }
+    } else if (action.type === 'SHOW_SHOP_DETAILS') {
+        console.log("Show shop details:", action.payload.shopCode);
+            // TODO. 샵 상세 정보 모달을 띄우는 등의 로직
+    }
+
+    }; 
 
     return (
         <div className={styles.container}>
@@ -300,6 +308,7 @@ export default function ChatWindow({
                         message={message}
                         assistantColor={assistant.color}
                         onActionClick={handleSendMessage}
+                        onApiActionClick={handleApiAction}
                     />
                 ))}
 

--- a/src/components/chat/ChatWindow.js
+++ b/src/components/chat/ChatWindow.js
@@ -286,8 +286,8 @@ const handleApiAction = (action, message) => {
         } else {
 
             // shops/ 페이지가 아닌 경우, shops/로 이동 후 샵 detail 페이지 전환
+            sessionStorage.setItem('pendingShopSelection', shopCode)
             router.push('/shops')
-            ShopsEvent.dispatch('selectShop', {shopCode})
         }
 
         if(onClose) onClose();

--- a/src/components/chat/ChatWindow.js
+++ b/src/components/chat/ChatWindow.js
@@ -139,7 +139,7 @@ export default function ChatWindow({
         const apiMap = {
             2: { // 샵관리자
                 'customer-helper': ChatbotAPI.admin.customer,
-                'reservation-helper': ChatbotAPI.admin.reservation.sendMessage
+                'reservation-helper': ChatbotAPI.admin.reservation
             },
             1: { // 일반회원
                 'booking-helper': ChatbotAPI.user.booking.sendMessage,

--- a/src/components/chat/ChatWindow.js
+++ b/src/components/chat/ChatWindow.js
@@ -4,7 +4,7 @@ import { useState, useRef, useEffect } from 'react';
 import { ChatbotAPI } from '@/lib/api/chatbot';
 import { useApi } from '@/hooks/useApi';
 import { ShopsEvent } from '@/lib/util/shopsEvent';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import MessageBubble from './MessageBubble';
 import QuickActions from './QuickActions';
 import styles from '@/styles/chat/ChatWindow.module.css';
@@ -35,6 +35,7 @@ export default function ChatWindow({
     const messagesEndRef = useRef(null);
     const { execute, loading } = useApi();
     const router = useRouter();
+    const pathname = usePathname(); // 현재 url 경로
 
     // 권한별 도우미별 빠른 액션들
     const getQuickActions = () => {
@@ -184,14 +185,16 @@ export default function ChatWindow({
                 if (assistant.id === 'booking-helper') {
                     const response = await execute(apiFunction, messageText);
 
+                    console.log('사용자 예약 도우미 응답:', response);
+
                     const botMessage = {
                         id: Date.now() + 1,
                         type: 'bot',
-                        text: response.message.text,
+                        text: response?.data?.message?.text || "챗봇과의 통신 중 오류가 발생했어요! 잠시 후 다시 시도해 주세요.",
                         timestamp: new Date(),
                         assistant: assistant.id,
-                        actions: response.actions || [],
-                        data: response.data || null,
+                        actions: response?.data?.actions || [],
+                        data: response?.data?.data || null,
                     };
 
                     setMessages(prev => [...prev, botMessage]);
@@ -274,15 +277,20 @@ const handleApiAction = (action, message) => {
     } else if (action.type === 'SHOW_SHOP_DETAILS') {
         const shopCode = action.payload.shopCode
 
-        console.log("shopCode 확인 :", shopCode);
-
-        if (message.data.recommendation.shopCode && message.data.recommendation.menus) {
-            // 샵 추천 내용이 있을 때만 router push
-            ShopsEvent.dispatch('selectShop', {shopCode})
-            if(onClose) onClose();
-        } else {
+        if (shopCode === null) {
             console.error('SHOW_SHOP_DETAILS action - shop 정보 비어있음: ', action)
         }
+
+        if (pathname === '/shops') {
+            ShopsEvent.dispatch('selectShop', {shopCode})
+        } else {
+
+            // shops/ 페이지가 아닌 경우, shops/로 이동 후 샵 detail 페이지 전환
+            router.push('/shops')
+            ShopsEvent.dispatch('selectShop', {shopCode})
+        }
+
+        if(onClose) onClose();
     }
     };
 

--- a/src/components/chat/FloatingChatSystem.js
+++ b/src/components/chat/FloatingChatSystem.js
@@ -273,16 +273,16 @@ export default function FloatingChatSystem({ userRole, userInfo, viewMode }) {
                     color: '#667eea',
                     apiEndpoint: '/api/v1/chatbot/user/booking',
                     requiredRole: 1
-                },
-                {
-                    id: 'support-helper',
-                    name: '고객지원',
-                    description: '이용 중 궁금한 점을 도와드려요',
-                    icon: '🛟',
-                    color: '#f093fb',
-                    apiEndpoint: '/api/v1/chatbot/user/support',
-                    requiredRole: 1
                 }
+                // { // 없는 기능 주석처리
+                //     id: 'support-helper',
+                //     name: '고객지원',
+                //     description: '이용 중 궁금한 점을 도와드려요',
+                //     icon: '🛟',
+                //     color: '#f093fb',
+                //     apiEndpoint: '/api/v1/chatbot/user/support',
+                //     requiredRole: 1
+                // }
             ];
         } else { // 비로그인 사용자 : 사용 안하면 삭제 예정
             return [
@@ -385,6 +385,7 @@ export default function FloatingChatSystem({ userRole, userInfo, viewMode }) {
                             userRole={getEffectiveUserRole()}
                             userInfo={userInfo}
                             viewMode={viewMode}
+                            onClose={toggleChat}
                         />
                     )}
                 </div>

--- a/src/components/chat/MessageBubble.js
+++ b/src/components/chat/MessageBubble.js
@@ -23,6 +23,23 @@ export default function MessageBubble({ message, assistantColor, onActionClick, 
                             {index < message.text.split('\n').length - 1 && <br />}
                         </span>
                     ))}
+
+                {message.data?.sub_intent === 'new_recommendation' && 
+                message.data?.recommendation && 
+                message.data.recommendation.menus &&
+                message.data.recommendation.menus.length > 0 && ( // 메뉴가 있는 샵만 메뉴 렌더링
+                    <div>
+                    <hr/>
+                    <h3>{message.data.recommendation.shopName}</h3>
+                    <ul>
+                        {message.data.recommendation.menus.slice(0, 3).map(menu => (
+                            <li key={menu.menuCode}> {menu.menuName}</li> 
+                        ))}
+                    </ul>
+            </div>
+        )}
+
+
                 </div>
                 
                 <div className={styles.messageTime}>
@@ -53,7 +70,7 @@ export default function MessageBubble({ message, assistantColor, onActionClick, 
                         <button
                             key={index}
                             className={styles.actionButton}
-                            onClick={() => onApiActionClick(action)}
+                            onClick={() => onApiActionClick(action, message)}
                             style={{ '--assistant-color': assistantColor }}
                         >
                             {action.label}

--- a/src/components/chat/MessageBubble.js
+++ b/src/components/chat/MessageBubble.js
@@ -2,7 +2,7 @@
 
 import styles from '@/styles/chat/MessageBubble.module.css';
 
-export default function MessageBubble({ message, assistantColor, onActionClick }) {
+export default function MessageBubble({ message, assistantColor, onActionClick, onApiActionClick }) {
     const formatTime = (timestamp) => {
         return timestamp.toLocaleTimeString('ko-KR', { 
             hour: '2-digit', 
@@ -41,6 +41,22 @@ export default function MessageBubble({ message, assistantColor, onActionClick }
                             style={{ '--assistant-color': assistantColor }}
                         >
                             {action}
+                        </button>
+                    ))}
+                </div>
+            )}
+            
+            {/* 사용자 예약 챗봇 actions 렌더링 */}
+            {message.actions && message.actions.length > 0 && (
+                <div className={styles.suggestedActions}>
+                    {message.actions.map((action, index) => (
+                        <button
+                            key={index}
+                            className={styles.actionButton}
+                            onClick={() => onApiActionClick(action)}
+                            style={{ '--assistant-color': assistantColor }}
+                        >
+                            {action.label}
                         </button>
                     ))}
                 </div>

--- a/src/lib/api/chatbot.js
+++ b/src/lib/api/chatbot.js
@@ -51,16 +51,15 @@ export const ChatbotAPI = {
     // 일반회원용 API (userRole === 1)
     user: {
         booking: {
-            sendMessage: async (userId, message) => {
-                const response = await fetch(`/api/v1/user/${userId}/chatbot/booking`, {
+            sendMessage: async (query) => {
+                const response = await fetch(`${process.env.NEXT_PUBLIC_LLM_BASE_URL}/api/v1/reservation/chat`, {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json',
                         'Authorization': `Bearer ${localStorage.getItem('token')}`
                     },
                     body: JSON.stringify({
-                        message: message.text,
-                        messageType: message.type || 'general'
+                        query: query
                     })
                 });
                 

--- a/src/lib/api/chatbot.js
+++ b/src/lib/api/chatbot.js
@@ -52,14 +52,15 @@ export const ChatbotAPI = {
     user: {
         booking: {
             sendMessage: async (query) => {
-                const response = await fetch(`${process.env.NEXT_PUBLIC_LLM_BASE_URL}/api/v1/reservation/chat`, {
+                const response = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api/v1/reservation/chat`, {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json',
                         'Authorization': `Bearer ${localStorage.getItem('token')}`
                     },
                     body: JSON.stringify({
-                        query: query
+                        query: query,
+                        message: query
                     })
                 });
                 

--- a/src/lib/util/shopsEvent.js
+++ b/src/lib/util/shopsEvent.js
@@ -1,0 +1,11 @@
+export const ShopsEvent = {
+    on(event, callback) {
+    document.addEventListener(event, (e) => callback(e.detail));
+    },
+    dispatch(event, data) {
+    document.dispatchEvent(new CustomEvent(event, { detail: data }));
+    },
+    remove(event, callback) {
+    document.removeEventListener(event, callback);
+    }
+}


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가 <br>
- [ ] 기능 삭제 <br>
- [ ] 버그 수정 <br>
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 👍변경점

### 백엔드 포트에 정상 연결 (8000 -> 8080)
- 기존 서버 연결 방식에 대한 착오로 잘못 연결했던 포트 재연결
- 달라진 응답 형태에 따라 포맷 방식 수정
### 유저 예약 챗봇에 프론트 페이지 연결
- shopId가 필요 없는 질문 형태 -> assistant.id에 따라 분기 처리
- 페이지 이동 시 router가 너무 빨리 동작해 shopCode 가져올 수 없는 문제 -> sessionStorage 활용
### 카카오맵 지도가 빈 화면으로 표시되는 문제 해결
- onLoad 객체가 수행되지 않음 -> 지도 객체가 이미 존재한다면 지도 초기화 함수 실행

## 스크린샷 (선택)
- 빠른 액션 (예약 확인/취소/변경)
   - 예약 변경 시 불가능하다는 안내 메시지 출력됨
   - [예약 내역 조회하기] 버튼 클릭 => 챗봇 창이 닫히면서 /shops/reservation으로 이동
<img width="346" height="457" alt="스크린샷 2025-08-25 15 39 06" src="https://github.com/user-attachments/assets/e8e11699-f811-4b4e-82de-8e941b0483e8" />   
   
- 빠른 액션 (샵 추천)
   - 사용자가 입력한 키워드로 검색한 결과 중 인기 샵 출력
   - [샵 예약하러 가기] 버튼 클릭 => 챗봇 창이 닫히면서 예약 가능한 샵 상세 조회 페이지로 이동
<img width="352" height="432" alt="스크린샷 2025-08-25 15 39 17" src="https://github.com/user-attachments/assets/c4deec5d-e7c7-4c53-9fa9-04307db114c1" />
 
closed #116 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 채팅 응답의 액션 버튼으로 페이지 이동 및 샵 상세 보기 지원, 이동 시 채팅창 자동 닫힘.
  - 예약/추천 응답에 따른 액션 버튼과 추천 샵/메뉴(최대 3개) 표시.
  - 샵 목록 화면이 외부 이벤트로 특정 샵을 자동 선택하고, 보류된 선택을 재방문 시 복원.

- 변경
  - 고객 화면에서 지원 도우미 제거, 예약/추천 도우미만 제공.
  - 빠른 실행 항목 “새 예약”을 “샵 추천”으로 변경.

- 버그 수정
  - Kakao 지도 스크립트 로드 타이밍에 따른 초기화 누락 방지.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->